### PR TITLE
Improve postprocess time

### DIFF
--- a/Source/YoloV8/Extensions/ImageSharpExtensions.cs
+++ b/Source/YoloV8/Extensions/ImageSharpExtensions.cs
@@ -7,16 +7,22 @@ public static class ImageSharpExtensions
     {
         var width = image.Width;
         var height = image.Height;
+        var totalPixels = width * height;
 
-        Parallel.For(0, width, x =>
+        var flag = image.DangerousTryGetSinglePixelMemory(out Memory<TPixel> memory);
+
+        if (flag)
         {
-            Parallel.For(0, height, y =>
+            Parallel.For(0, totalPixels, index =>
             {
+                int x = index % width;
+                int y = index / width;
+
                 var point = new Point(x, y);
-                var pixel = image[x, y];
+                var pixel = memory.Span[index];
 
                 action(point, pixel);
             });
-        });
+        }
     }
 }

--- a/Source/YoloV8/Extensions/ImageSharpExtensions.cs
+++ b/Source/YoloV8/Extensions/ImageSharpExtensions.cs
@@ -7,12 +7,12 @@ public static class ImageSharpExtensions
     {
         var width = image.Width;
         var height = image.Height;
-        var totalPixels = width * height;
 
         var flag = image.DangerousTryGetSinglePixelMemory(out Memory<TPixel> memory);
 
         if (flag)
         {
+            var totalPixels = width * height;
             Parallel.For(0, totalPixels, index =>
             {
                 int x = index % width;
@@ -22,6 +22,19 @@ public static class ImageSharpExtensions
                 var pixel = memory.Span[index];
 
                 action(point, pixel);
+            });
+        }
+        else
+        {
+            Parallel.For(0, width, x =>
+            {
+                for (int y = 0; y < height; y++)
+                {
+                    var point = new Point(x, y);
+                    var pixel = image[x, y];
+
+                    action(point, pixel);
+                }
             });
         }
     }

--- a/Source/YoloV8/Extensions/ImageSharpExtensions.cs
+++ b/Source/YoloV8/Extensions/ImageSharpExtensions.cs
@@ -5,37 +5,47 @@ public static class ImageSharpExtensions
     public static void ForEachPixel<TPixel>(this Image<TPixel> image, Action<Point, TPixel> action)
         where TPixel : unmanaged, IPixel<TPixel>
     {
+        if (ForEachPixelOptimized(image, action))
+            return;
+
         var width = image.Width;
         var height = image.Height;
 
-        var flag = image.DangerousTryGetSinglePixelMemory(out Memory<TPixel> memory);
-
-        if (flag)
+        Parallel.For(0, width, x =>
         {
-            var totalPixels = width * height;
-            Parallel.For(0, totalPixels, index =>
+            for (int y = 0; y < height; y++)
             {
-                int x = index % width;
-                int y = index / width;
-
                 var point = new Point(x, y);
-                var pixel = memory.Span[index];
+                var pixel = image[x, y];
 
                 action(point, pixel);
-            });
-        }
-        else
-        {
-            Parallel.For(0, width, x =>
-            {
-                for (int y = 0; y < height; y++)
-                {
-                    var point = new Point(x, y);
-                    var pixel = image[x, y];
+            }
+        });
+    }
 
-                    action(point, pixel);
-                }
-            });
-        }
+    private static bool ForEachPixelOptimized<TPixel>(this Image<TPixel> image, Action<Point, TPixel> action)
+        where TPixel : unmanaged, IPixel<TPixel>
+    {
+        var succes = image.DangerousTryGetSinglePixelMemory(out Memory<TPixel> memory);
+
+        if (succes == false)
+            return false;
+
+        var width = image.Width;
+        var height = image.Height;
+        var totalPixels = width * height;
+
+        Parallel.For(0, totalPixels, index =>
+        {
+            int x = index % width;
+            int y = index / width;
+
+            var point = new Point(x, y);
+            var pixel = memory.Span[index];
+
+            action(point, pixel);
+        });
+
+        return true;
     }
 }

--- a/Source/YoloV8/Parsers/DetectionOutputParser.cs
+++ b/Source/YoloV8/Parsers/DetectionOutputParser.cs
@@ -33,12 +33,12 @@ internal readonly struct DetectionOutputParser
 
         Parallel.For(0, output.Dimensions[2], i =>
         {
-            Parallel.For(0, metadata.Classes.Count, j =>
+            for (int j = 0; j < metadata.Classes.Count; j++)
             {
                 var confidence = output[0, j + 4, i];
 
                 if (confidence <= parameters.Confidence)
-                    return;
+                    continue;
 
                 var x = output[0, 0, i];
                 var y = output[0, 1, i];
@@ -60,7 +60,7 @@ internal readonly struct DetectionOutputParser
 
                 var box = new BoundingBox(name, rectangle, confidence);
                 boxes.Add(box);
-            });
+            }
         });
 
         var selected = boxes.NonMaxSuppression(x => x.Rectangle,

--- a/Source/YoloV8/Parsers/PoseOutputParser.cs
+++ b/Source/YoloV8/Parsers/PoseOutputParser.cs
@@ -35,12 +35,12 @@ internal readonly struct PoseOutputParser
 
         Parallel.For(0, output.Dimensions[2], i =>
         {
-            Parallel.For(0, metadata.Classes.Count, j =>
+            for (int j = 0; j < metadata.Classes.Count; j++)
             {
                 var confidence = output[0, j + 4, i];
 
                 if (confidence < parameters.Confidence)
-                    return;
+                    continue;
 
                 var x = output[0, 0, i];
                 var y = output[0, 1, i];
@@ -82,7 +82,7 @@ internal readonly struct PoseOutputParser
 
                 var box = new PoseBoundingBox(name, rectangle, confidence, keypoints);
                 boxes.Add(box);
-            });
+            }
         });
 
         var selected = boxes.NonMaxSuppression(x => x.Rectangle,

--- a/Source/YoloV8/Parsers/PoseOutputParser.cs
+++ b/Source/YoloV8/Parsers/PoseOutputParser.cs
@@ -62,7 +62,7 @@ internal readonly struct PoseOutputParser
 
                 var keypoints = new List<Keypoint>();
 
-                Parallel.For(0, shape.Count, k =>
+                for(int k = 0; k < shape.Count; k++)
                 {
                     var offset = k * shape.Channels + 4 + metadata.Classes.Count;
 
@@ -78,7 +78,7 @@ internal readonly struct PoseOutputParser
 
                     var keypoint = new Keypoint(k, pointX, pointY, pointConfidence);
                     keypoints.Add(keypoint);
-                });
+                }
 
                 var box = new PoseBoundingBox(name, rectangle, confidence, keypoints);
                 boxes.Add(box);

--- a/Source/YoloV8/Parsers/SegmentationOutputParser.cs
+++ b/Source/YoloV8/Parsers/SegmentationOutputParser.cs
@@ -36,12 +36,12 @@ internal readonly struct SegmentationOutputParser
 
         Parallel.For(0, output0.Dimensions[2], i =>
         {
-            Parallel.For(0, metadata.Classes.Count, j =>
+            for (int j = 0; j < metadata.Classes.Count; j++)
             {
                 var confidence = output0[0, j + 4, i];
 
                 if (confidence <= parameters.Confidence)
-                    return;
+                    continue;
 
                 var x = output0[0, 0, i];
                 var y = output0[0, 1, i];
@@ -75,7 +75,7 @@ internal readonly struct SegmentationOutputParser
 
                 var box = new SegmentationBoundingBox(name, rectangle, confidence, mask);
                 boxes.Add(box);
-            });
+            }
         });
 
         var selected = boxes.NonMaxSuppression(x => x.Rectangle,


### PR DESCRIPTION
1. Modified the loop in the `OutputParser.Parse()` function.
2. Changed the approach to traversing pixels in the `Image.ForEachPixel()` function.