### PR TITLE
Fix default font for Windows environment to support both English and Chinese

### DIFF
--- a/Source/YoloV8/Plotting/PlottingOptions.cs
+++ b/Source/YoloV8/Plotting/PlottingOptions.cs
@@ -14,11 +14,11 @@ public abstract class PlottingOptions
 
     private static FontFamily GetDefaultFontFamily()
     {
-        if (OperatingSystem.IsWindows())
-            return SystemFonts.Get("Arial");
+        if (OperatingSystem.IsWindows() && SystemFonts.TryGet("Microsoft YaHei", out FontFamily family))
+            return family;
 
-        if (OperatingSystem.IsAndroid())
-            return SystemFonts.Get("Robot");
+        if (OperatingSystem.IsAndroid() && SystemFonts.TryGet("Robot", out family))
+            return family;
 
         return SystemFonts.Families.First();
     }


### PR DESCRIPTION
Adjusting the `Arabic` font to `Microsoft YaHei` font
`Microsoft YaHei` is also included by default in Windows systems